### PR TITLE
Get rid of the 'let' for webpack minify work properly.

### DIFF
--- a/context.js
+++ b/context.js
@@ -119,7 +119,7 @@ function isContext (e) {
 }
 
 function createCanvas () {
-	let canvas = document.createElement('canvas')
+	var canvas = document.createElement('canvas')
 	canvas.style.position = 'absolute'
 	canvas.style.top = 0
 	canvas.style.left = 0


### PR DESCRIPTION
ES6 syntax included node packages couldn't be minifies with 'react-app', so for this reason i just get rid of the ES6 'let' and used ES5 'var' keyword instead. 

Thank you.