### PR TITLE
Check Image constructor for supporting WebWorker

### DIFF
--- a/texture.js
+++ b/texture.js
@@ -136,7 +136,7 @@ function setTexture (gl, name, options) {
 			image.src = data
 			image._src = data
 		}
-		else if (data instanceof Image && !data.complete) {
+		else if ('Image' in self && data instanceof Image && !data.complete) {
 			image = data
 		}
 


### PR DESCRIPTION
WebGL can work in WebWorker via OffscreenCanvas.
However, WebWorker hasnot Image constructor, so `texture()` will fail.

This PR check Image constructor in global object.