### PR TITLE
get the gl-context so that it works on IE11

### DIFF
--- a/context.js
+++ b/context.js
@@ -71,16 +71,12 @@ module.exports = function setContext (o) {
 
 	// make sure there is context
 	if (!o.gl) {
-		try {
-			o.gl = o.canvas.getContext('webgl', o.attrs)
-		} catch (e) {
+		['webgl', 'experimental-webgl', 'webgl-experimental'].some(function (c) {
 			try {
-				o.gl = o.canvas.getContext('experimental-webgl', o.attrs)
-			}
-			catch (e) {
-				o.gl = o.canvas.getContext('webgl-experimental', o.attrs)
-			}
-		}
+				o.gl = o.canvas.getContext(c, o.attrs);
+			} catch (e) { /* no-op */ }
+			return o.gl;
+		});
 	}
 
 	return o.gl


### PR DESCRIPTION
Automatically getting the context does not work in IE11.

This is, because [`getContext`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) does not throw an error when the context is not supported… instead `null` is being returned. 

This PR fixes this and ensures IE11 compatibility.